### PR TITLE
Add a way to distinguish key moments

### DIFF
--- a/src/components/Table.svelte
+++ b/src/components/Table.svelte
@@ -199,11 +199,14 @@
         {#each filteredData as rows}
           <tr
             on:click={(e) => handleClick(e)}
-            class="title table__body__cell--border"
+            class="title table__body__cell--border {(rows.key_moment !== null) ? 'key-moment' : '' }"
           >
             <!-- event name/title -->
             <td class="table__body__cell table__body__cell--data"
               ><div class="table__body__cell__title-container">
+                {#if (rows.key_moment !== null) }
+                <span>o</span>
+                {/if}
                 <span class="icon-container" />{rows.activity.title}
               </div></td
             >

--- a/src/data.js
+++ b/src/data.js
@@ -20,6 +20,7 @@ export default function getData() {
           image_source: row.image_source,
           key_moment: row.key_moment,
         },
+        key_moment: (row.key_moment) ? row.key_moment : null,
         category: row.category,
         category_name: row.category_name,
         speaker: row.speaker,

--- a/src/scss/components/_table.scss
+++ b/src/scss/components/_table.scss
@@ -153,6 +153,10 @@
     transition: $transition__link;
   }
 
+  .key-moment {
+    background-color: burlywood;
+  }
+
   .title {
     cursor: pointer;
   }


### PR DESCRIPTION
Added a random color to the `<tr>` and a `<span>` to distinguish a key moment.
![image](https://github.com/CSIS-iLab/poni-table/assets/51330062/32dfa6ed-3b4f-4839-be7b-33d7db3e7800)
When we are working on the final styles, we must decide how we want to show a key moment. The original option was adding an icon on an extra column, and the other one it can be changing the `<tr>` background color. Also, we need to check with the program if they think it is necessary to add a filter by key moments.