### PR TITLE
Make date column wider

### DIFF
--- a/src/scss/components/_table.scss
+++ b/src/scss/components/_table.scss
@@ -64,8 +64,8 @@
       }
 
       &:nth-child(2) {
-        min-width: rem(128);
-        max-width: rem(128);
+        min-width: rem(150);
+        max-width: rem(150);
       }
 
       &:nth-child(3) {
@@ -316,8 +316,8 @@
     }
 
     &:nth-child(2) {
-      min-width: rem(128);
-      max-width: rem(128);
+      min-width: rem(150);
+      max-width: rem(150);
     }
 
     &:nth-child(3) {


### PR DESCRIPTION
Small change to the width of the date column to allow full date (MM/DD/YYYY) to fit on one line in advance of meeting with program today.